### PR TITLE
Fixes constructor fall back warnings in 0.7

### DIFF
--- a/src/TransformUtils.jl
+++ b/src/TransformUtils.jl
@@ -141,6 +141,22 @@ mutable struct Euler
     Euler(v::VectorFloatInt, q::Quaternion) = new(v[1],v[2],v[3], q)
 end
 
+#explicit convertion constructors
+SO3(ss::so3) = convert(SO3, ss)
+SO3(A::AngleAxis) = convert(SO3, A)
+SO3(q::Quaternion) = convert(SO3, q)
+SO3(E::Euler) = convert(SO3, E)
+
+Quaternion(ss::so3) = convert(Quaternion, ss)
+Quaternion(R::SO3) = convert(Quaternion, R)
+Quaternion(A::AngleAxis) = convert(Quaternion, A)
+Quaternion(E::Euler) = convert(Quaternion, E)
+
+AngleAxis(R::SO3) = convert(AngleAxis, R)
+AngleAxis(q::Quaternion) = convert(AngleAxis, q)
+
+Euler(SO3::SO3) = convert(Euler, SO3)
+Euler(q::Quaternion) = convert(Euler, q)
 
 mutable struct SE3
   R::SO3

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,28 @@ using Test
   SE3(T.t, q)
   SE3(T.t, R)
   SE3(T.t, A)
+  E = Euler(0)
+
+  RfromE = SO3(E)
+  RfromQ = SO3(q)
+  RfromA = SO3(A)
+  Rfromss = SO3(ss)
+
+  QfromE = Quaternion(E)
+  QfromR = Quaternion(R)
+  QfromA = Quaternion(A)
+  Qfromss = Quaternion(ss)
+
+  # AfromE = AngleAxis(E) # Convert not implemented yet
+  AfromR = AngleAxis(R)
+  AfromQ = AngleAxis(q)
+  # Afromss = AngleAxis(ss) # Convert not implemented yet
+
+  EfromR = Euler(R)
+  EfromQ = Euler(q)
+  # EfromA = Euler(A) # Convert not implemented yet
+  # Efromss = Euler(ss) # Convert not implemented yet
+
 end
 
 @testset "Ensure basic quaternion operations hold" begin


### PR DESCRIPTION
Fixes Warnings: Constructors no longer fall back to `convert`. A constructor `...` should be defined instead.